### PR TITLE
Update Transport.php

### DIFF
--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -129,8 +129,9 @@ class Transport
             },
             //onFailure
             function ($response) {
+                $code = $response->getCode();
                 // Ignore 400 level errors, as that means the server responded just fine
-                if (!(isset($response['code']) && $response['code'] >=400 && $response['code'] < 500)) {
+                if ($code < 400 || $code >= 500) {
                     // Otherwise schedule a check
                     $this->connectionPool->scheduleCheck();
                 }


### PR DESCRIPTION
Following to [issue 676](https://github.com/elastic/elasticsearch-php/issues/676), fix is still missing from 6.7.x release

Error `Cannot use object of type Elasticsearch\Common\Exceptions\Missing404Exception as array` is still encountered in 6.7.

This PR intend to backport Master's fix into previous release 6.7.x and 6.8.x

<!--
https://github.com/elastic/elasticsearch-php/issues/676
Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you signed [Contributor License Agreement](https://www.elastic.co/contributor-agreement)?
PR's (no matter how small) cannot be merged until the CLA has been signed.  It only needs to be signed once,
however.
> YES

- Have you read the [Contributing Guidelines](https://github.com/elastic/elasticsearch-php/blob/master/.github/CONTRIBUTING.md)?
> YES

If you answered yes to both, thanks for the PR and we'll get to it ASAP! :)

-->
